### PR TITLE
feat: upgrade to rxjs 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/ui-router/rx#readme",
   "peerDependencies": {
     "@uirouter/core": ">=5.0.0",
-    "rxjs": "^5.0.3"
+    "rxjs": "^6.0.0"
   },
   "devDependencies": {
     "@uirouter/core": "^5.0.17",
@@ -58,7 +58,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-uglify": "^3.0.0",
     "rollup-plugin-visualizer": "^0.6.0",
-    "rxjs": "^5.5.10",
+    "rxjs": "^6.1.0",
     "typescript": "^2.8.3"
   }
 }

--- a/src/ui-router-rx.ts
+++ b/src/ui-router-rx.ts
@@ -1,9 +1,7 @@
 /** @module rx */
 /** */
-import 'rxjs/add/operator/mergeMap';
-import 'rxjs/add/operator/map';
-import { Observable } from 'rxjs/Observable';
-import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { Observable, ReplaySubject } from 'rxjs';
+import { map, mergeMap } from 'rxjs/operators';
 import { Transition, UIRouter, StateDeclaration, UIRouterPlugin } from '@uirouter/core';
 
 export interface StatesChangedEvent {
@@ -28,8 +26,8 @@ export class UIRouterRx implements UIRouterPlugin {
 
   constructor(router: UIRouter) {
     let start$ = new ReplaySubject<Transition>(1);
-    let success$ = <Observable<Transition>>start$.mergeMap((t: Transition) => t.promise.then(() => t));
-    let params$ = success$.map((transition: Transition) => transition.params());
+    let success$ = <Observable<Transition>>start$.pipe(mergeMap((t: Transition) => t.promise.then(() => t)));
+    let params$ = success$.pipe(map((transition: Transition) => transition.params()));
 
     let states$ = new ReplaySubject<StatesChangedEvent>(1);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3860,11 +3860,11 @@ rollup@^0.58.1:
     "@types/estree" "0.0.38"
     "@types/node" "*"
 
-rxjs@^5.5.10:
-  version "5.5.10"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.10.tgz#fde02d7a614f6c8683d0d1957827f492e09db045"
+rxjs@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.1.0.tgz#833447de4e4f6427b9cec3e5eb9f56415cd28315"
   dependencies:
-    symbol-observable "1.0.1"
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.1:
   version "5.1.1"
@@ -4310,10 +4310,6 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-
 tar-pack@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
@@ -4407,6 +4403,10 @@ trim-newlines@^2.0.0:
 trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
+
+tslib@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
 tsscmp@~1.0.0:
   version "1.0.5"


### PR DESCRIPTION
This is the first step towards getting `@ui-router/angular` working with angular 6 (without requiring the `rxjs-compat` package to be installed)

Any changes please let me know 😄 